### PR TITLE
Add the Azure Boards badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,3 @@
+[![Board Status](https://promegateam.visualstudio.com/460ac57f-4d06-47d3-9f31-0937288d2750/45620a5d-720d-46bc-bb5b-74617f87b9ec/_apis/work/boardbadge/61309d16-2f16-4ef2-8944-9c46fabea81b)](https://promegateam.visualstudio.com/460ac57f-4d06-47d3-9f31-0937288d2750/_boards/board/t/45620a5d-720d-46bc-bb5b-74617f87b9ec/Microsoft.RequirementCategory)
 # hello-promega
 Repo to test Azure deployment with actions


### PR DESCRIPTION
Add the Azure Boards badge for the board used to track the work for this repository. Fixes AB#15584. See the [status badge configuration](https://aka.ms/azureboardsgithub-badge) documentation for more information.